### PR TITLE
Fix refetch query with different variables, removes console logs

### DIFF
--- a/packages/do-react-apollo/src/provider/provider.test.js
+++ b/packages/do-react-apollo/src/provider/provider.test.js
@@ -146,7 +146,6 @@ describe("Provider", () => {
         }
       };
       const Container = withDO(Component);
-      console.log('container', Container);
       const state = renderer.create(
         <ReactApolloProvider graphqlURL="https://test.com/graphql">
           <Container />

--- a/packages/do-react/src/useDO/mapVariablesToQueryFields.js
+++ b/packages/do-react/src/useDO/mapVariablesToQueryFields.js
@@ -3,14 +3,25 @@ export const mapVariablesToQueryFields = (variables, queryFields) => {
   const res = Object.keys(variables)
     .reduce((queryFields, key) => {
       if (Array.isArray(queryFields[key])) {
+        const {
+          _variables,
+          ...qf // extract old _variables
+        } = queryFields[key][0]
         queryFields[key][0] = {
           _variables: variables[key],
-          ...queryFields[key][0],
+          ...qf,
         }
+
+
       } else {
+        const {
+          _variables,
+          ...qf // extract old _variables
+        } = queryFields[key]
+
         queryFields[key] = {
           _variables: variables[key],
-          ...queryFields[key],
+          ...qf,
         }
       }
       return queryFields;

--- a/packages/do-react/src/withDO/index.js
+++ b/packages/do-react/src/withDO/index.js
@@ -139,7 +139,6 @@ export default function withDO(WrappedComponent) {
     }
 
     render() {
-      console.log(this.context);
       if (WrappedComponent.defaultProps && WrappedComponent.defaultProps.$do) {
         const $do = merge(
           WrappedComponent.defaultProps.$do,


### PR DESCRIPTION
This is still hotfix, the mapVariablesToQueryFields (extracted from withDO) deserves a little rework because it's mutating original data. 